### PR TITLE
Error: type List<dynamic> is not a subtype of type Map<String, dynamic>

### DIFF
--- a/src/database/db_auth.js
+++ b/src/database/db_auth.js
@@ -13,7 +13,7 @@ const addTokens = async (user, _accessToken, _refreshToken) => {
             refreshToken: _refreshToken,
         };
         //const result = await auth.findOneAndUpdate(filter, data);
-        const result = await auth.insertMany(data);
+        const result = await auth.create(data);
         return result;
     } catch (error) {
         logger.error(error);


### PR DESCRIPTION
When the user clicks login a type error is shown for the first time, then the second click it works.

Changes: replace [insertMany] mongoose function with [create] as insertMany will wrap the object within an array. For the second hit backend will just update existing token with [findOneAndUpdate] function so it will override array with the single object.